### PR TITLE
Add option to right-align FPS display

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,9 @@ out
 *.iml
 .idea
 
+# vscode
+.vscode
+
 # gradle
 build
 .gradle

--- a/src/main/java/vice/magnesium_extras/config/MagnesiumExtrasConfig.java
+++ b/src/main/java/vice/magnesium_extras/config/MagnesiumExtrasConfig.java
@@ -15,6 +15,7 @@ public class MagnesiumExtrasConfig
     public static ConfigValue<String> fadeInQuality;
 
     public static ConfigValue<String> fpsCounterMode;
+    public static ConfigValue<Boolean> fpsCounterAlignRight;
     public static ConfigValue<Integer> fpsCounterPosition;
     public static ForgeConfigSpec.ConfigValue<Integer> cloudHeight;
 
@@ -55,6 +56,7 @@ public class MagnesiumExtrasConfig
 
         builder.Block("FPS Counter", b -> {
             fpsCounterMode = b.define("Display FPS Counter (OFF, SIMPLE, ADVANCED)", "ADVANCED");
+            fpsCounterAlignRight = b.define("Right-align FPS Counter", false);
             fpsCounterPosition = b.define("FPS Counter Distance", 12);
         });
 

--- a/src/main/java/vice/magnesium_extras/mixins/FrameCounter/FrameCounterMixin.java
+++ b/src/main/java/vice/magnesium_extras/mixins/FrameCounter/FrameCounterMixin.java
@@ -43,6 +43,7 @@ public class FrameCounterMixin
         else
             displayString = String.valueOf(fps);
 
+        boolean textAlignRight = MagnesiumExtrasConfig.fpsCounterAlignRight.get();
         float textPos = (int)MagnesiumExtrasConfig.fpsCounterPosition.get();
 
         int textAlpha = 200;
@@ -57,7 +58,14 @@ public class FrameCounterMixin
         // Prevent FPS-Display to render outside screenspace
         float maxTextPosX = client.getWindow().getGuiScaledWidth() - client.font.width(displayString);
         float maxTextPosY = client.getWindow().getGuiScaledHeight() - client.font.lineHeight;
-        textPos = Math.min(textPos, maxTextPosX);
+        float textPosX, textPosY;
+        if (textAlignRight)
+            textPosX = maxTextPosX - client.font.width(displayString) - textPos;
+        else
+            textPosX = Math.min(textPos, maxTextPosX);
+        textPosX = Math.min(Math.max(textPosX, 0), maxTextPosX);
+        textPosY = Math.min(textPos, maxTextPosY);
+
 
         int drawColor = ((textAlpha & 0xFF) << 24) | textColor;
 
@@ -65,12 +73,12 @@ public class FrameCounterMixin
         {
             GL11.glPushMatrix();
             GL11.glScalef(fontScale, fontScale, fontScale);
-            client.font.drawShadow(matrixStack, displayString, textPos, textPos, drawColor);
+            client.font.drawShadow(matrixStack, displayString, textPosX, textPosY, drawColor);
             GL11.glPopMatrix();
         }
         else
         {
-            client.font.drawShadow(matrixStack, displayString, textPos, textPos, drawColor);
+            client.font.drawShadow(matrixStack, displayString, textPosX, textPosY, drawColor);
         }
     }
 
@@ -103,4 +111,3 @@ public class FrameCounterMixin
         return fps + " | MIN " + vice.magnesium_extras.features.FrameCounter.MinFrameProvider.getLastMinFrame() + " | AVG " + runningAverageFPS;
     }
 }
-

--- a/src/main/java/vice/magnesium_extras/mixins/FrameCounter/FrameCounterMixin.java
+++ b/src/main/java/vice/magnesium_extras/mixins/FrameCounter/FrameCounterMixin.java
@@ -60,7 +60,7 @@ public class FrameCounterMixin
         float maxTextPosY = client.getWindow().getGuiScaledHeight() - client.font.lineHeight;
         float textPosX, textPosY;
         if (textAlignRight)
-            textPosX = maxTextPosX - client.font.width(displayString) - textPos;
+            textPosX = client.getWindow().getGuiScaledWidth() - client.font.width(displayString) - textPos;
         else
             textPosX = Math.min(textPos, maxTextPosX);
         textPosX = Math.min(Math.max(textPosX, 0), maxTextPosX);

--- a/src/main/java/vice/magnesium_extras/mixins/SodiumConfig/SodiumGameOptionsMixin.java
+++ b/src/main/java/vice/magnesium_extras/mixins/SodiumConfig/SodiumGameOptionsMixin.java
@@ -64,10 +64,19 @@ public class SodiumGameOptionsMixin
                 .setImpact(OptionImpact.LOW)
                 .build();
 
+        OptionImpl<SodiumGameOptions, Boolean> displayFpsAlignRight = OptionImpl.createBuilder(Boolean.class, sodiumOpts)
+                .setName("Right-align FPS Display")
+                .setTooltip("Aligns the FPS display to the right side of the screen. Useful if you have other overlays that show on the left side of the screen. Does nothing if the Display FPS option is set to Off.")
+                .setControl(TickBoxControl::new)
+                .setBinding(
+                        (options, value) -> MagnesiumExtrasConfig.fpsCounterAlignRight.set(value),
+                        (options) -> MagnesiumExtrasConfig.fpsCounterAlignRight.get())
+                .setImpact(OptionImpact.LOW)
+                .build();
 
         Option<Integer> displayFpsPos = OptionImpl.createBuilder(Integer.TYPE, sodiumOpts)
                 .setName("FPS Display Position")
-                .setTooltip("Offsets the FPS display a few pixels")
+                .setTooltip("Offsets the FPS display from the top-left or top-right corner of the screen.")
                 .setControl((option) -> {
                     return new SliderControl(option, 4, 64, 2, ControlValueFormatter.quantity("Pixels"));
                 })
@@ -79,6 +88,7 @@ public class SodiumGameOptionsMixin
 
         groups.add(OptionGroup.createBuilder()
                 .add(displayFps)
+                .add(displayFpsAlignRight)
                 .add(displayFpsPos)
                 .build());
 


### PR DESCRIPTION
Useful for those with mods that place overlays in the upper-left corner and do not allow the position of said overlay to be customized. (e.g. Ars Nouveau with its source jar fill level or FTB Ultimine).