### PR TITLE
Remove deprecated dependency: Textrue's Embeddium Options

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -65,7 +65,6 @@ dependencies {
     // DEPENDENCIES
     implementation fg.deobf("org.embeddedt:embeddium-${mcversion}:${embeddiumversion}")
     implementation fg.deobf("curse.maven:jei-238222:${jeiversion}")
-    runtimeOnly fg.deobf("curse.maven:textrues-embeddium-options-910506:${embeddiumoptionsversion}")
     runtimeOnly fg.deobf("curse.maven:oculus-581495:${oculusversion}")
 
     // MOD SUPPORT

--- a/gradle.properties
+++ b/gradle.properties
@@ -33,9 +33,8 @@ mappings_version=2023.09.03
 #### Dependencies ####
 #####################
 embeddiumversion=0.3.0-git.abf0fe6+mc1.20.1
-embeddiumrange=[0.2.5,)
+embeddiumrange=[0.3.16,)
 
-embeddiumoptionsversion=5069200
 oculusversion=4767500
 jeiversion=4712868
 

--- a/src/main/resources/META-INF/mods.toml
+++ b/src/main/resources/META-INF/mods.toml
@@ -35,10 +35,3 @@ displayTest="IGNORE_SERVER_VERSION"
     versionRange="${embeddiumrange}"
     ordering="AFTER"
     side="CLIENT"
-
-[[dependencies.${modid}]]
-    modId="textrues_embeddium_options"
-    mandatory=true
-    versionRange="*"
-    ordering="AFTER"
-    side="CLIENT"


### PR DESCRIPTION
Embeddium 0.3.16 adds similar functionality to TEO, and as such the mod is discontinued and Embeddium no longer supports loading it. As such, Embeddium/Magnesium Extras no longer works as is. (See issues #63 and #67)

The modification here allows it to still work; all it does is remove the deprecated dependency, and the Embeddium dependency allows it to still run without issues. The Embeddium dependency is also updated to require version 0.3.16 or later alongside this change, as it will break on prior versions due to not having TEO-like functionality.